### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,21 @@ This helps reduce errors and frustration when entering URLs on portable devices.
 
 1. Install the app.
 
+    For DDEV v1.23.5 or above run
+
+    ```shell
+    ddev add-on get tyler36/ddev-qr
+    ```
+
+    For earlier versions of DDEV run
+
     ```shell
     ddev get tyler36/ddev-qr
+    ```
+
+    Then restart your project
+
+    ```shell
     ddev restart
     ```
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.