### PR TITLE
Add #ddev-generated to config.qr.yaml

### DIFF
--- a/config.qr.yaml
+++ b/config.qr.yaml
@@ -1,2 +1,3 @@
+#ddev-generated
 webimage_extra_packages:
   - qrencode


### PR DESCRIPTION
I happened to notice I had a config.qr.yaml kicking around after removing the add-on. It's because it was missing the #ddev-generated.